### PR TITLE
Set Nightly Rust as default, store config in better places

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,7 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use tokio::{
 	fs::File,
+    fs::create_dir_all,
 	io::{AsyncReadExt, AsyncWriteExt},
+};
+
+use std::{
+    env,
+    path::{Path,PathBuf},
 };
 
 // Structure for holding all the settings
@@ -18,32 +24,63 @@ pub struct Settings {
 	pub downloader: DownloaderConfig,
 }
 
+// On UNIX systems (eg. Linux, *BSD, even macOS), follow the
+// XDG Base Directory Specification for storing config files
+#[cfg(target_family = "unix")]
+fn get_config_folder_path() -> PathBuf {
+    match env::var("XDG_CONFIG_HOME") {
+
+        Ok(v) => Path::new(&v).join("down_on_spot").to_path_buf(),
+
+        Err(_) => Path::new(&env::var("HOME").unwrap()).join(".config/down_on_spot"),
+
+    }
+}
+
+// On Windows, follow whatever windows does for AppData
+#[cfg(target_family = "windows")]
+fn get_config_folder_path() -> PathBuf {
+    Path::new(&env::var("APPDATA").unwrap()).join("down_on_spot");
+}
+
 impl Settings {
-	// Create new instance
-	pub fn new(username: &str, password: &str, client_id: &str, client_secret: &str) -> Settings {
-		Settings {
-			username: username.to_string(),
-			password: password.to_string(),
-			client_id: client_id.to_string(),
-			client_secret: client_secret.to_string(),
-			refresh_ui_seconds: 1,
-			downloader: DownloaderConfig::new(),
-		}
-	}
+    // Create new instance
+    pub fn new(username: &str, password: &str, client_id: &str, client_secret: &str) -> Settings {
+        Settings {
+            username: username.to_string(),
+            password: password.to_string(),
+            client_id: client_id.to_string(),
+            client_secret: client_secret.to_string(),
+            refresh_ui_seconds: 1,
+            downloader: DownloaderConfig::new(),
+        }
+    }
 
-	// Serialize the settings to a json file
-	pub async fn save(&self) -> Result<(), SpotifyError> {
-		let data = serde_json::to_string_pretty(self)?;
-		let mut file = File::create("settings.json").await?;
-		file.write_all(data.as_bytes()).await?;
-		Ok(())
-	}
+    // Save config
+    pub async fn save(&self) -> Result<(), SpotifyError> {
+        // Get and create config folder path, generate config file path
+        let config_folder_path = get_config_folder_path();
+        create_dir_all(&config_folder_path).await?;
+        let config_file_path = config_folder_path.join("settings.json");
 
-	// Deserialize the settings from a json file
-	pub async fn load() -> Result<Settings, SpotifyError> {
-		let mut file = File::open("settings.json").await?;
-		let mut buf = String::new();
-		file.read_to_string(&mut buf).await?;
-		Ok(serde_json::from_str(&buf)?)
-	}
+
+        // Serialize the settings to a json file
+        let data = serde_json::to_string_pretty(self)?;
+        let mut file = File::create(config_file_path).await?;
+        file.write_all(data.as_bytes()).await?;
+        Ok(())
+    }
+
+    // Load config
+    pub async fn load() -> Result<Settings, SpotifyError> {
+        // Get config folder path, generate config file path
+        let config_folder_path = get_config_folder_path();
+        let config_file_path = config_folder_path.join("settings.json");
+
+        // Deserialize the settings from a json file
+        let mut file = File::open(config_file_path).await?;
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).await?;
+        Ok(serde_json::from_str(&buf)?)
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,14 +3,14 @@ use crate::error::SpotifyError;
 use serde::{Deserialize, Serialize};
 
 use tokio::{
+	fs::create_dir_all,
 	fs::File,
-    fs::create_dir_all,
 	io::{AsyncReadExt, AsyncWriteExt},
 };
 
 use std::{
-    env,
-    path::{Path,PathBuf},
+	env,
+	path::{Path, PathBuf},
 };
 
 // Structure for holding all the settings
@@ -28,59 +28,56 @@ pub struct Settings {
 // XDG Base Directory Specification for storing config files
 #[cfg(target_family = "unix")]
 fn get_config_folder_path() -> PathBuf {
-    match env::var("XDG_CONFIG_HOME") {
+	match env::var("XDG_CONFIG_HOME") {
+		Ok(v) => Path::new(&v).join("down_on_spot").to_path_buf(),
 
-        Ok(v) => Path::new(&v).join("down_on_spot").to_path_buf(),
-
-        Err(_) => Path::new(&env::var("HOME").unwrap()).join(".config/down_on_spot"),
-
-    }
+		Err(_) => Path::new(&env::var("HOME").unwrap()).join(".config/down_on_spot"),
+	}
 }
 
 // On Windows, follow whatever windows does for AppData
 #[cfg(target_family = "windows")]
 fn get_config_folder_path() -> PathBuf {
-    Path::new(&env::var("APPDATA").unwrap()).join("down_on_spot");
+	Path::new(&env::var("APPDATA").unwrap()).join("down_on_spot");
 }
 
 impl Settings {
-    // Create new instance
-    pub fn new(username: &str, password: &str, client_id: &str, client_secret: &str) -> Settings {
-        Settings {
-            username: username.to_string(),
-            password: password.to_string(),
-            client_id: client_id.to_string(),
-            client_secret: client_secret.to_string(),
-            refresh_ui_seconds: 1,
-            downloader: DownloaderConfig::new(),
-        }
-    }
+	// Create new instance
+	pub fn new(username: &str, password: &str, client_id: &str, client_secret: &str) -> Settings {
+		Settings {
+			username: username.to_string(),
+			password: password.to_string(),
+			client_id: client_id.to_string(),
+			client_secret: client_secret.to_string(),
+			refresh_ui_seconds: 1,
+			downloader: DownloaderConfig::new(),
+		}
+	}
 
-    // Save config
-    pub async fn save(&self) -> Result<(), SpotifyError> {
-        // Get and create config folder path, generate config file path
-        let config_folder_path = get_config_folder_path();
-        create_dir_all(&config_folder_path).await?;
-        let config_file_path = config_folder_path.join("settings.json");
+	// Save config
+	pub async fn save(&self) -> Result<(), SpotifyError> {
+		// Get and create config folder path, generate config file path
+		let config_folder_path = get_config_folder_path();
+		create_dir_all(&config_folder_path).await?;
+		let config_file_path = config_folder_path.join("settings.json");
 
+		// Serialize the settings to a json file
+		let data = serde_json::to_string_pretty(self)?;
+		let mut file = File::create(config_file_path).await?;
+		file.write_all(data.as_bytes()).await?;
+		Ok(())
+	}
 
-        // Serialize the settings to a json file
-        let data = serde_json::to_string_pretty(self)?;
-        let mut file = File::create(config_file_path).await?;
-        file.write_all(data.as_bytes()).await?;
-        Ok(())
-    }
+	// Load config
+	pub async fn load() -> Result<Settings, SpotifyError> {
+		// Get config folder path, generate config file path
+		let config_folder_path = get_config_folder_path();
+		let config_file_path = config_folder_path.join("settings.json");
 
-    // Load config
-    pub async fn load() -> Result<Settings, SpotifyError> {
-        // Get config folder path, generate config file path
-        let config_folder_path = get_config_folder_path();
-        let config_file_path = config_folder_path.join("settings.json");
-
-        // Deserialize the settings from a json file
-        let mut file = File::open(config_file_path).await?;
-        let mut buf = String::new();
-        file.read_to_string(&mut buf).await?;
-        Ok(serde_json::from_str(&buf)?)
-    }
+		// Deserialize the settings from a json file
+		let mut file = File::open(config_file_path).await?;
+		let mut buf = String::new();
+		file.read_to_string(&mut buf).await?;
+		Ok(serde_json::from_str(&buf)?)
+	}
 }


### PR DESCRIPTION
There's a thing called the "XDG Base Desktop Specification" that defines where folders and files should be saved on Linux systems (although it is generally followed by most UNIX-based systems). My commits change where the `settings.json` is stored and loaded from. Also, for convenience sake, I added a `rust-toolchain` file containing the rust version so that it gets used when compiling, without resorting to changing your global toolchain default.