### PR TITLE
docs: update and fix the 'Usage/Examples' section in README.MD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
+/credentials_cache
+
 settings.json
 libmp3lame.dll

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I am not responsible in any way for the usage of the source code.
 ## Features
 
 -   Works with free Spotify accounts (if using free-librespot fork)
--   Download 96, 160kbit/s audio with a free account, 256 and 320 kbit/s audio with a premium account from Spotify, directly
+-   Download 96, 160kbit/s audio with a free, 256 and 320 kbit/s audio with a premium account from Spotify, directly
 -   Multi-threaded
 -   Search for tracks
 -   Download tracks, playlists, albums and artists

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo build --release
 If you get a linker error, you might need to download the [standard libmp3lame](https://www.rarewares.org/mp3-lame-libraries.php#libmp3lame) library.
 On OS X, it should be enough to just run `brew install lame`, provided you have [Homebrew](https://brew.sh/) installed.
 
-## Usage / Examples
+## Usage/Examples
 
 Running DownOnSpot once will create the default configuration file in the same directory as your shell.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On OS X, the `settings.json` file is created globally for the logged in user and
 Apart from your Spotify username and password, you will need to login in to the Spotify developer dashboard and [create a new private application](https://developer.spotify.com/dashboard/applications). Fill in the `client_id` and `client_secret` in your `settings.json` from your newly created app.
 All the other settings should be self-explanatory, conversion from Ogg to MP3 is disabled by default.
 
-Note: If you're on a free spotify account, remember to set down the quality to 160 ("Q320" -> "Q160"), otherwise you'll get an "Audio Key Error" since free account can't go past 160kbit/s.
+> **Note**: If you're on a free Spotify account, remember to set down the quality to 160 ("Q320" -> "Q160"). Otherwise, you'll get an "Audio Key Error" since the free account can't exceed 160kbit/s.
 
 ### Template variables
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I am not responsible in any way for the usage of the source code.
 ## Features
 
 -   Works with free Spotify accounts (if using free-librespot fork)
--   Download 96, 160kbit/s audio with a free, 256 and 320 kbit/s audio with a premium account from Spotify, directly
+-   Download 96, 160kbit/s audio with a free account, 256 and 320 kbit/s audio with a premium account from Spotify, directly
 -   Multi-threaded
 -   Search for tracks
 -   Download tracks, playlists, albums and artists
@@ -68,7 +68,7 @@ cargo build --release
 If you get a linker error, you might need to download the [standard libmp3lame](https://www.rarewares.org/mp3-lame-libraries.php#libmp3lame) library.
 On OS X, it should be enough to just run `brew install lame`, provided you have [Homebrew](https://brew.sh/) installed.
 
-## Usage/ Examples
+## Usage / Examples
 
 Running DownOnSpot once will create the default configuration file in the same directory as your shell.
 
@@ -85,6 +85,8 @@ On OS X, the `settings.json` file is created globally for the logged in user and
 
 Apart from your Spotify username and password, you will need to login in to the Spotify developer dashboard and [create a new private application](https://developer.spotify.com/dashboard/applications). Fill in the `client_id` and `client_secret` in your `settings.json` from your newly created app.
 All the other settings should be self-explanatory, conversion from Ogg to MP3 is disabled by default.
+
+Note: If you're on a free spotify account, remember to set down the quality to 160 ("Q320" -> "Q160"), otherwise you'll get an "Audio Key Error" since free account can't go past 160kbit/s.
 
 ### Template variables
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo build --release
 If you get a linker error, you might need to download the [standard libmp3lame](https://www.rarewares.org/mp3-lame-libraries.php#libmp3lame) library.
 On OS X, it should be enough to just run `brew install lame`, provided you have [Homebrew](https://brew.sh/) installed.
 
-## Usage/Examples
+## Usage/ Examples
 
 Running DownOnSpot once will create the default configuration file in the same directory as your shell.
 


### PR DESCRIPTION
I added the folder "credentials_cache" to .gitignore just in case if someone did an oopsie.

I also added a note to the Usage / Example section so if anyone with free accounts forget or let them know to lower the audio quality so they don't get the "Audio Key Error" when trying to use the tool.