### PR TITLE
feat: Add `env_logger`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /credentials_cache
+/downloads
 
 settings.json
 libmp3lame.dll

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,8 +1656,7 @@ dependencies = [
 [[package]]
 name = "librespot"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c9952ef48968f8184a4a87f8576982426ebe623342d5a28f7d9c4978e4a44"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "base64 0.13.1",
  "env_logger 0.9.3",
@@ -1683,8 +1682,7 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c176a31355e1ea8e0b9c4ced19df4947bfe4770661c25c142b6fba2365940d9d"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "aes-ctr",
  "byteorder",
@@ -1699,8 +1697,7 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffafb6a443e9445ccb3d5d591573b5b1da3c89a9b8846c63ba2c3710210d3ec"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "form_urlencoded",
  "futures-util",
@@ -1720,8 +1717,7 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046349f25888e644bf02d9c5de0164b2a493d29aa4ce18e1ad0b756da9b55d6d"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "aes",
  "base64 0.13.1",
@@ -1761,8 +1757,7 @@ dependencies = [
 [[package]]
 name = "librespot-discovery"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa877d18f6150364012cb4be5682d62d7c712c88bae2d0d01720fd7c15e2f06"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "aes-ctr",
  "base64 0.13.1",
@@ -1783,8 +1778,7 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b80361fcbcb5092056fd47c08c34d5d51b08385d8efb6941c0d3e46d032c21c"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1797,8 +1791,7 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5190a0b9bcc7f70ee4196a6b4a1c731d405ca130d4a6fcd4c561cfdde8b7cfb7"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "byteorder",
  "cpal",
@@ -1823,8 +1816,7 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d3ac6196ac0ea67bbe039f56d6730a5d8b31502ef9bce0f504ed729dcb39f"
+source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
 dependencies = [
  "glob",
  "protobuf 2.28.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
+ "stderrlog",
  "tokio",
  "url",
  "winres",
@@ -2871,6 +2872,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "stderrlog"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c910772f992ab17d32d6760e167d2353f4130ed50e796752689556af07dc6b"
+dependencies = [
+ "chrono",
+ "is-terminal",
+ "log",
+ "termcolor",
+ "thread_local",
+]
+
+[[package]]
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,9 +2960,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -2981,6 +2995,16 @@ checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -829,6 +829,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "env_logger 0.11.1",
  "futures",
  "id3",
  "lame",
@@ -841,7 +842,6 @@ dependencies = [
  "sanitize-filename",
  "serde",
  "serde_json",
- "stderrlog",
  "tokio",
  "url",
  "winres",
@@ -863,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +882,19 @@ dependencies = [
  "humantime",
  "log",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e7cf40684ae96ade6232ed84582f40ce0a66efcd43a5117aef610534f8e0b8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1637,7 +1660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea4c9952ef48968f8184a4a87f8576982426ebe623342d5a28f7d9c4978e4a44"
 dependencies = [
  "base64 0.13.1",
- "env_logger",
+ "env_logger 0.9.3",
  "futures-util",
  "getopts",
  "hex",
@@ -2872,19 +2895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stderrlog"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c910772f992ab17d32d6760e167d2353f4130ed50e796752689556af07dc6b"
-dependencies = [
- "chrono",
- "is-terminal",
- "log",
- "termcolor",
- "thread_local",
-]
-
-[[package]]
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,16 +3005,6 @@ checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,7 +1632,8 @@ dependencies = [
 [[package]]
 name = "librespot"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4c9952ef48968f8184a4a87f8576982426ebe623342d5a28f7d9c4978e4a44"
 dependencies = [
  "base64 0.13.1",
  "env_logger",
@@ -1658,7 +1659,8 @@ dependencies = [
 [[package]]
 name = "librespot-audio"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c176a31355e1ea8e0b9c4ced19df4947bfe4770661c25c142b6fba2365940d9d"
 dependencies = [
  "aes-ctr",
  "byteorder",
@@ -1673,7 +1675,8 @@ dependencies = [
 [[package]]
 name = "librespot-connect"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffafb6a443e9445ccb3d5d591573b5b1da3c89a9b8846c63ba2c3710210d3ec"
 dependencies = [
  "form_urlencoded",
  "futures-util",
@@ -1693,7 +1696,8 @@ dependencies = [
 [[package]]
 name = "librespot-core"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046349f25888e644bf02d9c5de0164b2a493d29aa4ce18e1ad0b756da9b55d6d"
 dependencies = [
  "aes",
  "base64 0.13.1",
@@ -1733,7 +1737,8 @@ dependencies = [
 [[package]]
 name = "librespot-discovery"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa877d18f6150364012cb4be5682d62d7c712c88bae2d0d01720fd7c15e2f06"
 dependencies = [
  "aes-ctr",
  "base64 0.13.1",
@@ -1754,7 +1759,8 @@ dependencies = [
 [[package]]
 name = "librespot-metadata"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b80361fcbcb5092056fd47c08c34d5d51b08385d8efb6941c0d3e46d032c21c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1767,7 +1773,8 @@ dependencies = [
 [[package]]
 name = "librespot-playback"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190a0b9bcc7f70ee4196a6b4a1c731d405ca130d4a6fcd4c561cfdde8b7cfb7"
 dependencies = [
  "byteorder",
  "cpal",
@@ -1792,7 +1799,8 @@ dependencies = [
 [[package]]
 name = "librespot-protocol"
 version = "0.4.2"
-source = "git+ssh://git@github.com/oSumAtrIX/free-librespot.git#f28fa264528dc85f8f325c18e8461b0f2b43dca1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d3ac6196ac0ea67bbe039f56d6730a5d8b31502ef9bce0f504ed729dcb39f"
 dependencies = [
  "glob",
  "protobuf 2.28.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = "0.11"
 colored = "2"
 lame = "0.1"
 aspotify = "0.7.1"
-librespot = { git = "ssh://git@github.com/oSumAtrIX/free-librespot.git" }
+librespot = { version = "0.4.2" }
 async-std = { version = "1.12", features = ["attributes", "tokio1"] }
 serde_json = "1.0"
 async-stream = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ oggvorbismeta = "0.1"
 sanitize-filename = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.20", features = ["fs"] }
+stderrlog = "0.6.0"
 
 [package.metadata.winres]
 OriginalFilename = "DownOnSpot.exe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ oggvorbismeta = "0.1"
 sanitize-filename = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.20", features = ["fs"] }
-stderrlog = "0.6.0"
+env_logger = "0.11.1"
 
 [package.metadata.winres]
 OriginalFilename = "DownOnSpot.exe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = "0.11"
 colored = "2"
 lame = "0.1"
 aspotify = "0.7.1"
-librespot = { version = "0.4.2" }
+librespot = { git = "ssh://git@github.com/oSumAtrIX/free-librespot.git" }
 async-std = { version = "1.12", features = ["attributes", "tokio1"] }
 serde_json = "1.0"
 async-stream = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,17 +19,6 @@ use std::time::{Duration, Instant};
 #[cfg(not(windows))]
 #[tokio::main]
 async fn main() {
-	match env::var("RUST_LOG") {
-		Ok(v) => {
-			if v == "DEBUG" {
-				stderrlog::new().module(module_path!()).verbosity(stderrlog::LogLevelNum::Debug).init().unwrap();
-			}
-		},
-		Err(_) => {
-			// noop - don't init logger
-		}
-	}
-	
 	start().await;
 }
 
@@ -44,6 +33,7 @@ async fn main() {
 }
 
 async fn start() {
+	env_logger::init();
 	let settings = match Settings::load().await {
 		Ok(settings) => {
 			println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,17 @@ use std::time::{Duration, Instant};
 #[cfg(not(windows))]
 #[tokio::main]
 async fn main() {
+	match env::var("RUST_LOG") {
+		Ok(v) => {
+			if v == "DEBUG" {
+				stderrlog::new().module(module_path!()).verbosity(stderrlog::LogLevelNum::Debug).init().unwrap();
+			}
+		},
+		Err(_) => {
+			// noop - don't init logger
+		}
+	}
+	
 	start().await;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ async fn main() {
 
 async fn start() {
 	env_logger::init();
+
 	let settings = match Settings::load().await {
 		Ok(settings) => {
 			println!(


### PR DESCRIPTION
DownOnSpot was already using some log macros in a few places, however the `log` crate on it's own doesn't do anything, we need an actual implementation to output the logs (https://github.com/rust-lang/log?tab=readme-ov-file#in-executables)

This PR adds `env_logger` (https://github.com/rust-cli/env_logger) as an implementation.

This allows us to view the DownOnSpot logs, as well as logs by the libraries we're using. This can help to better debug issues by tracing who is doing what where.

Additionally, this logger outputs to `stderr` , so by redirecting stdout to `/dev/null` (since there are some clear-screen escape sequences being printed), we can stick to just the logs.

Example: All logs

```
$ RUST_LOG=DEBUG cargo run -- "https://open.spotify.com/track/0hlniElQOr5tvSKBaSpAQi" 1>/dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/down_on_spot 'https://open.spotify.com/track/0hlniElQOr5tvSKBaSpAQi'`
[2024-02-12T05:37:40Z WARN  librespot_core::apresolve] Ignoring blacklisted access point ap-gue1.spotify.com:4070
[2024-02-12T05:37:40Z WARN  librespot_core::apresolve] Ignoring blacklisted access point ap-gew4.spotify.com:80
[2024-02-12T05:37:40Z INFO  librespot_core::session] Connecting to AP "ap-gae2.spotify.com:4070"
[2024-02-12T05:37:41Z INFO  librespot_core::session] Authenticated as "[REDACTED]" !
[2024-02-12T05:37:41Z DEBUG librespot_core::session] new Session[0]
[2024-02-12T05:37:41Z DEBUG librespot_core::session] Session[0] strong=2 weak=1
[2024-02-12T05:37:41Z INFO  librespot_core::session] Country: "IN"
[2024-02-12T05:37:41Z DEBUG reqwest::connect] starting new connection: https://accounts.spotify.com/
[2024-02-12T05:37:41Z DEBUG reqwest::connect] starting new connection: https://api.spotify.com/
[2024-02-12T05:37:41Z DEBUG reqwest::connect] starting new connection: https://accounts.spotify.com/
[2024-02-12T05:37:41Z DEBUG reqwest::connect] starting new connection: https://api.spotify.com/
[2024-02-12T05:37:42Z DEBUG librespot::component] new MercuryManager
[2024-02-12T05:37:42Z INFO  down_on_spot::downloader] 0hlniElQOr5tvSKBaSpAQi Using OGG_VORBIS_320 format.
[2024-02-12T05:37:42Z ERROR down_on_spot::downloader] Download job for track 0hlniElQOr5tvSKBaSpAQi failed. Already Downloaded
[2024-02-12T05:37:42Z DEBUG librespot_core::session] drop Dispatch
[2024-02-12T05:37:42Z DEBUG librespot_core::session] drop Session[0]
[2024-02-12T05:37:42Z DEBUG librespot::component] drop MercuryManager
```

Example: Only DownOnSpot logs

```
$ RUST_LOG=down_on_spot=DEBUG cargo run -- "https://open.spotify.com/track/0hlniElQOr5tvSKBaSpAQi" 1>/dev/null
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/down_on_spot 'https://open.spotify.com/track/0hlniElQOr5tvSKBaSpAQi'`
[2024-02-12T05:37:51Z INFO  down_on_spot::downloader] 0hlniElQOr5tvSKBaSpAQi Using OGG_VORBIS_320 format.
[2024-02-12T05:37:51Z ERROR down_on_spot::downloader] Download job for track 0hlniElQOr5tvSKBaSpAQi failed. Already Downloaded
```

**Note: This PR only adds env_logger, I plan to make a follow up PR which actually adds more DEBUG & TRACE logs.**