### PR TITLE
feat: Select market to support track relinking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
 }
 
 async fn start() {
-    env_logger::init();
+	env_logger::init();
 
 	let settings = match Settings::load().await {
 		Ok(settings) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod settings;
 mod spotify;
 mod tag;
 
+use aspotify::Market;
 use async_std::task;
 use colored::Colorize;
 use downloader::{DownloadState, Downloader};
@@ -33,8 +34,6 @@ async fn main() {
 }
 
 async fn start() {
-	env_logger::init();
-
 	let settings = match Settings::load().await {
 		Ok(settings) => {
 			println!(
@@ -84,6 +83,11 @@ async fn start() {
 		&settings.password,
 		&settings.client_id,
 		&settings.client_secret,
+		if let Some(countrycode) = settings.market {
+			Some(Market::Country(countrycode))
+		} else {
+			None
+		},
 	)
 	.await
 	{

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ mod settings;
 mod spotify;
 mod tag;
 
-use aspotify::Market;
 use arg::Args;
 use async_std::task;
 use colored::Colorize;
@@ -81,11 +80,7 @@ async fn start() {
 		&settings.password,
 		&settings.client_id,
 		&settings.client_secret,
-		if let Some(countrycode) = settings.market {
-			Some(Market::Country(countrycode))
-		} else {
-			None
-		},
+		settings.market_country_code,
 	)
 	.await
 	{

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ async fn main() {
 }
 
 async fn start() {
+    env_logger::init();
+
 	let settings = match Settings::load().await {
 		Ok(settings) => {
 			println!(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,7 +23,7 @@ pub struct Settings {
 	pub client_secret: String,
 	pub refresh_ui_seconds: u64,
 	pub downloader: DownloaderConfig,
-	pub market: Option<CountryCode>,
+	pub market_country_code: Option<CountryCode>,
 }
 
 // On UNIX systems (eg. Linux, *BSD, even macOS), follow the
@@ -61,7 +61,7 @@ impl Settings {
 			client_secret: client_secret.to_string(),
 			refresh_ui_seconds: 1,
 			downloader: DownloaderConfig::new(),
-			market: None,
+			market_country_code: None,
 		}
 	}
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,5 +1,6 @@
 use crate::downloader::DownloaderConfig;
 use crate::error::SpotifyError;
+use aspotify::CountryCode;
 use serde::{Deserialize, Serialize};
 
 use tokio::{
@@ -22,6 +23,7 @@ pub struct Settings {
 	pub client_secret: String,
 	pub refresh_ui_seconds: u64,
 	pub downloader: DownloaderConfig,
+	pub market: Option<CountryCode>,
 }
 
 // On UNIX systems (eg. Linux, *BSD, even macOS), follow the
@@ -50,6 +52,7 @@ impl Settings {
 			client_secret: client_secret.to_string(),
 			refresh_ui_seconds: 1,
 			downloader: DownloaderConfig::new(),
+			market: Some(CountryCode::USA),
 		}
 	}
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -52,7 +52,7 @@ impl Settings {
 			client_secret: client_secret.to_string(),
 			refresh_ui_seconds: 1,
 			downloader: DownloaderConfig::new(),
-			market: Some(CountryCode::USA),
+			market: None,
 		}
 	}
 

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -1,5 +1,5 @@
 use aspotify::{
-	Album, Artist, Client, ClientCredentials, ItemType, Playlist, PlaylistItemType, Track,
+	Album, Artist, Client, ClientCredentials, ItemType, Market, Playlist, PlaylistItemType, Track,
 	TrackSimplified,
 };
 use librespot::core::authentication::Credentials;
@@ -16,6 +16,7 @@ pub struct Spotify {
 	// librespotify sessopm
 	pub session: Session,
 	pub spotify: Client,
+	pub market: Option<Market>,
 }
 
 impl Spotify {
@@ -25,6 +26,7 @@ impl Spotify {
 		password: &str,
 		client_id: &str,
 		client_secret: &str,
+		market: Option<Market>,
 	) -> Result<Spotify, SpotifyError> {
 		// librespot
 		let credentials = Credentials::with_password(username, password);
@@ -43,7 +45,11 @@ impl Spotify {
 		};
 		let spotify = Client::new(credentials);
 
-		Ok(Spotify { session, spotify })
+		Ok(Spotify {
+			session,
+			spotify,
+			market,
+		})
 	}
 
 	/// Parse URI or URL into URI
@@ -78,7 +84,7 @@ impl Spotify {
 		let id = parts[1];
 		match parts[0] {
 			"track" => {
-				let track = self.spotify.tracks().get_track(id, None).await?;
+				let track = self.spotify.tracks().get_track(id, self.market).await?;
 				Ok(SpotifyItem::Track(track.data))
 			}
 			"playlist" => {
@@ -193,6 +199,7 @@ impl Clone for Spotify {
 		Self {
 			session: self.session.clone(),
 			spotify: Client::new(self.spotify.credentials.clone()),
+			market: self.market.clone(),
 		}
 	}
 }

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -88,11 +88,15 @@ impl Spotify {
 				Ok(SpotifyItem::Track(track.data))
 			}
 			"playlist" => {
-				let playlist = self.spotify.playlists().get_playlist(id, None).await?;
+				let playlist = self
+					.spotify
+					.playlists()
+					.get_playlist(id, self.market)
+					.await?;
 				Ok(SpotifyItem::Playlist(playlist.data))
 			}
 			"album" => {
-				let album = self.spotify.albums().get_album(id, None).await?;
+				let album = self.spotify.albums().get_album(id, self.market).await?;
 				Ok(SpotifyItem::Album(album.data))
 			}
 			"artist" => {
@@ -125,7 +129,7 @@ impl Spotify {
 			let page = self
 				.spotify
 				.playlists()
-				.get_playlists_items(id, 100, offset, None)
+				.get_playlists_items(id, 100, offset, self.market)
 				.await?;
 			items.append(
 				&mut page
@@ -158,7 +162,7 @@ impl Spotify {
 			let page = self
 				.spotify
 				.albums()
-				.get_album_tracks(id, 50, offset, None)
+				.get_album_tracks(id, 50, offset, self.market)
 				.await?;
 			items.append(&mut page.data.items.to_vec());
 
@@ -178,7 +182,7 @@ impl Spotify {
 			let page = self
 				.spotify
 				.artists()
-				.get_artist_albums(id, None, 50, offset, None)
+				.get_artist_albums(id, None, 50, offset, self.market)
 				.await?;
 
 			for album in &mut page.data.items.iter() {

--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -1,6 +1,6 @@
 use aspotify::{
-	Album, Artist, Client, ClientCredentials, ItemType, Market, Playlist, PlaylistItemType, Track,
-	TrackSimplified,
+	Album, Artist, Client, ClientCredentials, CountryCode, ItemType, Market, Playlist,
+	PlaylistItemType, Track, TrackSimplified,
 };
 use librespot::core::authentication::Credentials;
 use librespot::core::cache::Cache;
@@ -26,7 +26,7 @@ impl Spotify {
 		password: &str,
 		client_id: &str,
 		client_secret: &str,
-		market: Option<Market>,
+		market_country_code: Option<CountryCode>,
 	) -> Result<Spotify, SpotifyError> {
 		// librespot
 		let credentials = Credentials::with_password(username, password);
@@ -48,7 +48,11 @@ impl Spotify {
 		Ok(Spotify {
 			session,
 			spotify,
-			market,
+			market: if let Some(countrycode) = market_country_code {
+				Some(Market::Country(countrycode))
+			} else {
+				None
+			},
 		})
 	}
 


### PR DESCRIPTION
Added configuration option to select market, which allows for following Relinked tracks. Solves #75. Not sure if this is the way you'd like to implement it, but it's a fix before the rewrite drops!