### PR TITLE
fix: Don't crash when attempting to download local tracks by skipping them

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -85,35 +85,23 @@ impl Downloader {
 		let item = self.spotify.resolve_uri(&uri).await?;
 		match item {
 			SpotifyItem::Track(t) => {
-				if t.id.is_some() && !t.is_local {
+				if !t.is_local {
 					self.add_to_queue(t.into()).await;
 				}
 			}
 			SpotifyItem::Album(a) => {
 				let tracks = self.spotify.full_album(&a.id).await?;
-				let queue: Vec<Download> = tracks
-					.into_iter()
-					.filter(|t| t.id.is_some() && !t.is_local)
-					.map(|t| t.into())
-					.collect();
+				let queue: Vec<Download> = tracks.into_iter().map(|t| t.into()).collect();
 				self.add_to_queue_multiple(queue).await;
 			}
 			SpotifyItem::Playlist(p) => {
 				let tracks = self.spotify.full_playlist(&p.id).await?;
-				let queue: Vec<Download> = tracks
-					.into_iter()
-					.filter(|t| t.id.is_some() && !t.is_local)
-					.map(|t| t.into())
-					.collect();
+				let queue: Vec<Download> = tracks.into_iter().map(|t| t.into()).collect();
 				self.add_to_queue_multiple(queue).await;
 			}
 			SpotifyItem::Artist(a) => {
 				let tracks = self.spotify.full_artist(&a.id).await?;
-				let queue: Vec<Download> = tracks
-					.into_iter()
-					.filter(|t| t.id.is_some() && !t.is_local)
-					.map(|t| t.into())
-					.collect();
+				let queue: Vec<Download> = tracks.into_iter().map(|t| t.into()).collect();
 				self.add_to_queue_multiple(queue).await;
 			}
 

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -790,16 +790,26 @@ impl From<aspotify::Track> for SearchResult {
 
 impl From<aspotify::Track> for Download {
 	fn from(val: aspotify::Track) -> Self {
-		Download {
-			id: 0,
-			track_id: val.id.unwrap(),
-			title: val.name,
-			subtitle: val
-				.artists
-				.first()
-				.map(|a| a.name.to_owned())
-				.unwrap_or_default(),
-			state: DownloadState::None,
+		if val.is_local || val.id.is_none() {
+			Download {
+				id: 0,
+				track_id: "This should not be a valid ID".to_string(),
+				title: "Local Track: ".to_owned() + &val.name,
+				subtitle: String::new(),
+				state: DownloadState::Error("Cannot Download Local Track".to_string()),
+			}
+		} else {
+			Download {
+				id: 0,
+				track_id: val.id.unwrap(),
+				title: val.name,
+				subtitle: val
+					.artists
+					.first()
+					.map(|a| a.name.to_owned())
+					.unwrap_or_default(),
+				state: DownloadState::None,
+			}
 		}
 	}
 }


### PR DESCRIPTION
Tracks with no id will crash the application (#84).

This PR fixes this by making the Download of a track with is_local or a None id into an error download. This causes DownOnSpot to correctly report the error, skip over the track, and continue without crashing.

This fix is a modification of the edit suggested by @Daprussiaduck

Closes #84