### PR TITLE
fix: Use cached credentials if available

### DIFF
--- a/src/spotify.rs
+++ b/src/spotify.rs
@@ -29,11 +29,15 @@ impl Spotify {
 		market_country_code: Option<CountryCode>,
 	) -> Result<Spotify, SpotifyError> {
 		// librespot
-		let credentials = Credentials::with_password(username, password);
+		let cache = Cache::new(Some(Path::new("credentials_cache")), None, None, None).unwrap();
+		let credentials = match cache.credentials() {
+			Some(creds) => creds,
+			None => Credentials::with_password(username, password),
+		};
 		let (session, _) = Session::connect(
 			SessionConfig::default(),
 			credentials,
-			Some(Cache::new(Some(Path::new("credentials_cache")), None, None, None).unwrap()),
+			Some(cache),
 			true,
 		)
 		.await?;


### PR DESCRIPTION
This allows the auth work-around explained here: https://github.com/oSumAtrIX/DownOnSpot/issues/93#issuecomment-2286869696

To use it:
- if existing valid credentials exist, it should still work
- if not, create a new credentials cache file with https://github.com/dspearson/librespot-auth
- replace `credentials_cache/credentials.json` with the newly generated one
